### PR TITLE
Dockerfile.rocm fix permissions error

### DIFF
--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -29,6 +29,7 @@ ENV PATH=/usr/bin/cmake:$PATH
 ENV PATH=/usr/bin/ctest:$PATH
 
 RUN git clone --single-branch --branch v$ONNXRUNTIME_VERSION --recursive https://github.com/Microsoft/onnxruntime
+RUN chmod +x onnxruntime/tools/ci_build/build.py
 RUN onnxruntime/tools/ci_build/build.py --allow_running_as_root --build_dir=build/Linux --config Release --build_wheel --update --build --parallel --skip_tests --cmake_extra_defines CMAKE_INSTALL_PREFIX=/usr/local/bin/cmake ONNXRUNTIME_VERSION=$ONNXRUNTIME_VERSION --use_rocm --rocm_home=/opt/rocm
 RUN pip install /facefusion/build/Linux/Release/dist/*.whl
 


### PR DESCRIPTION
Permissions error on onnxruntime/tools/ci_build/build.py

![image](https://github.com/facefusion/facefusion-docker/assets/37708320/3ad291b6-7916-4afe-9fa9-9c6ed5ee531f)

Added permissions fix on onnxruntime/tools/ci_build/build.py, it allows running the build.py so onnxruntime can be built for rocm