### PR TITLE
make Cuda docker work on WSL

### DIFF
--- a/docker-compose.cuda.yml
+++ b/docker-compose.cuda.yml
@@ -4,6 +4,10 @@ services:
    context: .
    dockerfile: Dockerfile.cuda
   command: [ 'python', 'facefusion.py', 'run', '--execution-providers', 'cuda' ]
+  environment:
+  # make it work on WSL2#
+  # see https://github.com/NVIDIA/nvidia-container-toolkit/issues/148
+  - NVIDIA_DISABLE_REQUIRE=1
   volumes:
   - .assets:/facefusion/.assets
   - .caches:/facefusion/.caches


### PR DESCRIPTION
Due to a bug between nvida-container-cli and how WSL works, cuda version is incorrectly detected.
As image is built with a specific and working version, version check can be safely skipped (with or without WSL).

See https://github.com/NVIDIA/nvidia-container-toolkit/issues/148 for original detail.
