### PR TITLE
Update docker-compose.rocm.yml to avoid capabilities error

### DIFF
--- a/docker-compose.rocm.yml
+++ b/docker-compose.rocm.yml
@@ -1,19 +1,17 @@
 services:
- facefusion-rocm:
-  build:
-   context: .
-   dockerfile: Dockerfile.rocm
-  command: [ 'python', 'facefusion.py', 'run', '--execution-providers', 'rocm' ]
-  volumes:
-  - .assets:/facefusion/.assets
-  - .caches:/facefusion/.caches
-  - .jobs:/facefusion/.jobs
-  ports:
-  - 7880:7860
-  deploy:
-   resources:
-    reservations:
-     devices:
-     - driver: rocm
-       count: all
-       capabilities: [ gpu, video ]
+  facefusion-rocm:
+    build:
+      context: .
+      dockerfile: Dockerfile.rocm
+    command: [ 'python', 'facefusion.py', 'run', '--execution-providers', 'rocm' ]
+    ports:
+      - 7860:7860
+    volumes:
+      - .assets:/facefusion/.assets
+      - .caches:/facefusion/.caches
+      - .jobs:/facefusion/.jobs
+    devices:
+      - /dev/kfd:/dev/kfd
+      - /dev/dri:/dev/dri
+    group_add:
+      - video


### PR DESCRIPTION
prior version of the YML would result in this error

`Attaching to facefusion-rocm-1\nError response from daemon: could not select device driver "rocm" with capabilities: [[gpu video]]`

these capabilities are CUDA / NVIDIA only so the ROCm docker compose command would not work.

updated docker-compose.rocm.yml confirmed working by @peter.r.r.r at facefusion's discord server

<img width="564" height="72" alt="image" src="https://github.com/user-attachments/assets/69b3b20b-e756-43c7-b21b-9dddffd28457" />
